### PR TITLE
Add PulseFeature

### DIFF
--- a/framework/features/PulseFeature.h
+++ b/framework/features/PulseFeature.h
@@ -1,0 +1,66 @@
+#ifndef PULSEFEATURE_H
+#define PULSEFEATURE_H
+
+#include "Feature.h"
+
+template<const char* const name, uint16_t gpio, bool invert = false, uint16_t damper = 0, uint16_t max_duration = 0>
+class PulseFeature : public Feature<name> {
+
+protected:
+    using Feature<name>::LOG;
+
+public:
+    PulseFeature(Device* device) :
+            Feature<name>(device),
+            lastChange(RTC.getRtcSeconds()) {
+        pinMode(gpio, OUTPUT);
+        digitalWrite(gpio, invert);
+        this->switchBackTimer.initializeMs(100, TimerDelegate(&PulseFeature::switchOff, this));
+        this->registerSubscription("pulse", Device::MessageCallback(&PulseFeature::onMessageReceived, this));
+
+        LOG.log("Initialized");
+    }
+
+    void doPulse(const int ms) {
+        switchBackTimer.setIntervalMs(ms);
+        digitalWrite(gpio, !invert);
+        switchBackTimer.start(false);
+    }
+
+protected:
+    virtual void publishCurrentState() {};
+
+private:
+    void onMessageReceived(const String& topic, const String& message) {
+        const uint32_t now = RTC.getRtcSeconds();
+
+        if (damper > 0) {
+            if (this->lastChange + damper > now) {
+                this->publish("error", "cooldown active, try again later", false);
+                LOG.log("message ignored because still in damping");
+                return;
+            }
+        }
+        const int value = atoi(message.c_str());
+        if (value <= 0) {
+            this->publish("error", "message parsed as 0", false);
+            LOG.log("Message parsed as 0 :", message);
+        } else if (value > max_duration) {
+            this->publish("error", "duration to long", false);
+            LOG.log("Message > max duration :", message);
+        } else {
+            this->publish("feedback", message, false);
+            doPulse(value);
+        }
+        this->lastChange = now;
+    }
+
+    void switchOff() {
+        digitalWrite(gpio, invert);
+    }
+
+    uint32_t lastChange;
+    Timer switchBackTimer;
+};
+
+#endif

--- a/framework/util/Damper.h
+++ b/framework/util/Damper.h
@@ -1,0 +1,29 @@
+
+#ifndef DAMPER_H
+#define DAMPER_H
+
+template<uint16_t damper_time = 0>
+class Damper {
+public:
+    Damper() : lastChange(RTC.getRtcNanoseconds()) {  }
+
+    bool isDamped() {
+        if(damper_time <= 0)
+          return false;
+
+        const uint64_t now = RTC.getRtcNanoseconds();
+
+        if (this->lastChange + ((uint64_t) damper_time * NS_PER_SECOND) > now) {
+            return true;
+        }
+
+        this->lastChange = now;
+
+        return false;
+    }
+
+private:
+    uint64_t lastChange;
+};
+
+#endif


### PR DESCRIPTION
The PulseFeature does not allow to send an ON or an OFF command,
it allows to send an „enable for x ms“-command. Can be usefull
for example when operating a bell that should ring for a short time
but reliably turn off after that time.

I'm not very used to writing C++ for ESP, so feedback on how to improve
this Pull Request is welcome.