### PR TITLE
Group clone/make into one layer. Remove build-folder

### DIFF
--- a/contrib/build-container/Dockerfile
+++ b/contrib/build-container/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:stretch-slim
 
 RUN apt-get update && apt-get install -y \
 	make \
@@ -14,7 +14,8 @@ RUN apt-get update && apt-get install -y \
 	gawk sed \
 	ncurses-dev \ 
 	libexpat-dev \
-	python python-dev python-serial
+	python python-dev python-serial \
+	&& rm -rf /var/lib/apt/lists/*
 
 # Create user
 RUN useradd -m builder
@@ -23,8 +24,9 @@ USER builder
 # Install ESP8266 SDK
 RUN git clone --recursive https://github.com/pfalcon/esp-open-sdk.git /home/builder/esp-open-sdk \
     && cd /home/builder/esp-open-sdk \
-    git reset --hard e8d757b1a70a5cf19df0afe23a769739c6cff343
-RUN cd /home/builder/esp-open-sdk; make VENDOR_SDK=1.5.4 STANDALONE=y
+    && git reset --hard e8d757b1a70a5cf19df0afe23a769739c6cff343 \
+    && cd /home/builder/esp-open-sdk; make VENDOR_SDK=1.5.4 STANDALONE=y \
+	&& rm -rf /home/builder/esp-open-sdk/crosstool-NG/.build
 
 ENV PATH /home/builder/esp-open-sdk/xtensa-lx106-elf/bin:$PATH
 ENV XTENSA_TOOLS_ROOT /home/builder/esp-open-sdk/xtensa-lx106-elf/bin
@@ -43,17 +45,16 @@ ENV PATH /home/builder/esptool:$PATH
 # Install esptool2
 RUN git clone --recursive https://github.com/raburton/esptool2 /home/builder/esptool2 \
     && cd /home/builder/esptool2 \
-    && git reset --hard ec0e2c72952f4fa8242eedd307c58a479d845abe
-RUN cd /home/builder/esptool2; make
+    && git reset --hard ec0e2c72952f4fa8242eedd307c58a479d845abe \
+    && cd /home/builder/esptool2; make
 
 ENV PATH /home/builder/esptool2:$PATH
 
 # Install sming
 RUN git clone https://github.com/SmingHub/Sming.git /home/builder/Sming \
     && cd /home/builder/Sming \
-    && git reset --hard 93340e19a1e1e68885a36976113bc400eb2be985
-#    && git reset --hard b0568b58db7d63d1078b29eea721554338932bc1
-RUN cd /home/builder/Sming/Sming; make clean; make
+    && git reset --hard 93340e19a1e1e68885a36976113bc400eb2be985 \
+    && cd /home/builder/Sming/Sming; make clean; make
 
 ENV COM_PORT /dev/ttyESP
 ENV COM_SPEED 115200


### PR DESCRIPTION
This reduces the final image size from ~4GB down to less than 1GB.

Next step would be to purge all debian packages which are just build-dependencys and are no longer needed after everthing is done.

Best regards,
Felix