### PR TITLE
Update Sming to 3.4.0 and cherry-pick a crashfix

### DIFF
--- a/contrib/build-container/Dockerfile
+++ b/contrib/build-container/Dockerfile
@@ -51,9 +51,12 @@ RUN git clone --recursive https://github.com/raburton/esptool2 /home/builder/esp
 ENV PATH /home/builder/esptool2:$PATH
 
 # Install sming
+ENV GIT_COMMITTER_NAME "dummy"
+ENV GIT_COMMITTER_EMAIL "dummy@example.com"
 RUN git clone https://github.com/SmingHub/Sming.git /home/builder/Sming \
     && cd /home/builder/Sming \
-    && git reset --hard 93340e19a1e1e68885a36976113bc400eb2be985 \
+    && git checkout 3.4.0 \
+    && git cherry-pick 89ac9a7eef61d8756dd82bb74b451951f2cfa000 \
     && cd /home/builder/Sming/Sming; make clean; make
 
 ENV COM_PORT /dev/ttyESP


### PR DESCRIPTION
As mentioned on IRC I found a crash while updating Sming from 3.3.0 to 3.4.0

```
ed94fb77d7e8a948e7fc6837844b48d1a94f933c is the first bad commit
commit ed94fb77d7e8a948e7fc6837844b48d1a94f933c
Author: tius2000 <github.misc@zoom.de>
Date:   Fri Sep 29 17:54:00 2017 +0200
    m_printf: stacksize reduced (#1097)

    reduced buffer size from 256 to 128 bytes
    allocate more stack if required
    size is no longer limited
:040000 040000 f299f91aea4ca60917d14d00ec10349042c53b3d ae4226b38120e1d5b658ccb8b8ca6b6f5f652145 M Sming
```

The cherry-pick is one commit ahead of 3.4.0 on the develop branch, and reverts this commit.

Tested successfully against a Sonoff S20 and a custom NodeMCU+BME280 device.