### PR TITLE
Update sming and esptool

### DIFF
--- a/contrib/build-container/Dockerfile
+++ b/contrib/build-container/Dockerfile
@@ -39,7 +39,7 @@ ENV SDK_BASE $SMING_HOME/third-party/ESP8266_NONOS_SDK
 # Install esptool
 RUN git clone --recursive https://github.com/themadinventor/esptool.git /home/builder/esptool \
     && cd /home/builder/esptool \
-    && git reset --hard a532bc42573861779b39b989c333e1b5bcc723ed
+    && git reset --hard ee00d8421353f43671e84c80cfbd465c33eee77d
 
 ENV PATH /home/builder/esptool:$PATH
 

--- a/contrib/build-container/Dockerfile
+++ b/contrib/build-container/Dockerfile
@@ -54,7 +54,7 @@ ENV PATH /home/builder/esptool2:$PATH
 # Install sming
 RUN git clone https://github.com/SmingHub/Sming.git /home/builder/Sming \
     && cd /home/builder/Sming \
-    && git reset --hard 4a0fec18235521e4369d111f111c2624fbd3203b \
+    && git reset --hard 31828f0d846b58f2e764c8985c085fc69cc1439f \
     && cd /home/builder/Sming/Sming; make clean; make
 
 ENV COM_PORT /dev/ttyESP


### PR DESCRIPTION
Fixes the include path issue for the Arduino Sensor library blocking #31.

Tested using the `example-bme280` device on a nodemcu v3 with a bme280 sensor.