### PR TITLE
update: improve reliability

### DIFF
--- a/framework/services/Update.h
+++ b/framework/services/Update.h
@@ -24,10 +24,14 @@ public:
 private:
     void onUpdateRequestReceived(const String& topic, const String& message);
     int onVersionReceived(HttpConnection& client, bool successful);
+    void checkImageHeader();
+    int onImageHeaderReceived(HttpConnection& client, bool successful);
+    void beginUpdate();
 
     Timer timer;
 
-    HttpClient http;
+    HttpClient http_version;
+    HttpClient http_image_check;
 
     rBootHttpUpdate* updater;
 };


### PR DESCRIPTION
- check for usable http response codes
- check image existance with HEAD request before flashing


Unfortunately this changeset doesn't work because Smings HTTPClient is very unreliable.

On the first update request I see a `GET` for the version info, and it tells me it requested the firmware image with a `HEAD` request, but such a request never arrives at the server.

On the second update request I see a `GET` for the version info, but it uses the wrong delegate reference and begins the update without the version check.

MADNESS!